### PR TITLE
Mark plugin as pure

### DIFF
--- a/src/Foreign/Storable/Generic/Plugin.hs
+++ b/src/Foreign/Storable/Generic/Plugin.hs
@@ -31,7 +31,8 @@ import Foreign.Storable.Generic.Plugin.Internal.Error
 -- | The plugin itself.
 plugin :: Plugin
 plugin = defaultPlugin {
-  installCoreToDos = install
+  installCoreToDos = install,
+  pluginRecompile = \_ -> pure NoForceRecompile
   }
 
 defFlags = Flags Some False


### PR DESCRIPTION
To avoid forcing unnecessary recompiles

I haven't actually read the source in enough detail to know if this
plugin is pure, but I'd be astonished if it isn't!