### PR TITLE
GHC-9.2 compatibility clutches

### DIFF
--- a/derive-storable-plugin.cabal
+++ b/derive-storable-plugin.cabal
@@ -16,7 +16,7 @@ category:            Foreign
 build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 cabal-version:       >=1.10
-tested-with:         GHC==8.2.2, GHC==8.4.2, GHC==8.6.5, GHC==8.8.1, GHC==8.10.2,GHC==9.0.1
+tested-with:         GHC==8.2.2, GHC==8.4.2, GHC==8.6.5, GHC==8.8.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2
 
 Flag sumtypes
   Description:   Use sumtypes within benchmark and tests.
@@ -32,7 +32,7 @@ library
                        , Foreign.Storable.Generic.Plugin.Internal.Predicates
                        , Foreign.Storable.Generic.Plugin.Internal.Types
   other-extensions:    DeriveGeneric, DeriveAnyClass, PatternGuards
-  build-depends:       base >=4.10 && <5, ghc >= 8.2 && < 9.1, ghci >= 8.2 && < 9.1, derive-storable >= 0.3 && < 0.4
+  build-depends:       base >=4.10 && <5, ghc >= 8.2 && < 9.3, ghci >= 8.2 && < 9.3, derive-storable >= 0.3 && < 0.4
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/src/Foreign/Storable/Generic/Plugin/Internal.hs
+++ b/src/Foreign/Storable/Generic/Plugin/Internal.hs
@@ -32,7 +32,12 @@ import qualified GHC.Types.Name as N (varName)
 import GHC.Types.SrcLoc (noSrcSpan)
 import GHC.Types.Unique (getUnique)
 import GHC.Driver.Main (hscCompileCoreExpr, getHscEnv)
+#if MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+import GHC.Driver.Env.Types (HscEnv)
+import GHC.Unit.Module.ModGuts (ModGuts(..))
+#else
 import GHC.Driver.Types (HscEnv,ModGuts(..))
+#endif
 import GHC.Core.Opt.Monad
     (CoreM, CoreToDo(..), 
      getHscEnv, getDynFlags, putMsg, putMsgS)
@@ -44,7 +49,7 @@ import GHC.Builtin.Types   (intDataCon)
 import GHC.Core.DataCon    (dataConWorkId,dataConOrigArgTys) 
 import GHC.Core.Make       (mkWildValBinder)
 import GHC.Utils.Outputable 
-    (cat, ppr, SDoc, showSDocUnsafe, showSDoc, 
+    (cat, ppr, SDoc, showSDocUnsafe,
      ($$), ($+$), hsep, vcat, empty,text, 
      (<>), (<+>), nest, int, colon,hcat, comma, 
      punctuate, fsep) 
@@ -73,7 +78,7 @@ import TysWiredIn (intDataCon)
 import DataCon    (dataConWorkId,dataConOrigArgTys) 
 import MkCore (mkWildValBinder)
 import Outputable 
-    (cat, ppr, SDoc, showSDocUnsafe, showSDoc, 
+    (cat, ppr, SDoc, showSDocUnsafe,
      ($$), ($+$), hsep, vcat, empty,text, 
      (<>), (<+>), nest, int, colon,hcat, comma, 
      punctuate, fsep) 
@@ -225,7 +230,6 @@ foundBinds_info flags ids = do
             other ->    text "The following bindings are to be optimised:"
                     $+$ nest 4 txt
         print_binding id = ppr id
-        max_nest = maximum $ 0 : map (length.(showSDoc dyn_flags).ppr) ids
         -- Print groups of types
         printer the_groups = case the_groups of
             [] -> return ()

--- a/src/Foreign/Storable/Generic/Plugin/Internal/Error.hs
+++ b/src/Foreign/Storable/Generic/Plugin/Internal/Error.hs
@@ -45,13 +45,13 @@ type CrashOnWarning = Bool
 data Flags = Flags Verbosity CrashOnWarning
 
 -- | All possible errors.
-data Error = TypeNotFound Id                       -- ^ Could not obtain the type from the id.
-           | RecBinding CoreBind                   -- ^ The binding is recursive and won't be substituted.
-           | CompilationNotSupported CoreBind      -- ^ The compilation-substitution is not supported for the given binding.
-           | CompilationError        CoreBind SDoc -- ^ Error during compilation. The CoreBind is to be returned.
-           | OrderingFailedBinds Int [CoreBind]    -- ^ Ordering failed for core bindings.
-           | OrderingFailedTypes Int [Type]        -- ^ Ordering failed for types
-           | OtherError          SDoc              -- ^ Any other error.
+data Error = TypeNotFound Id                         -- ^ Could not obtain the type from the id.
+           | RecBinding CoreBind                     -- ^ The binding is recursive and won't be substituted.
+           | CompilationNotSupported CoreBind        -- ^ The compilation-substitution is not supported for the given binding.
+           | CompilationError        CoreBind [SDoc] -- ^ Error during compilation. The CoreBind is to be returned.
+           | OrderingFailedBinds Int [CoreBind]      -- ^ Ordering failed for core bindings.
+           | OrderingFailedTypes Int [Type]          -- ^ Ordering failed for types
+           | OtherError          SDoc                -- ^ Any other error.
 
 pprTypeNotFound :: Verbosity -> Id -> SDoc
 pprTypeNotFound None _  = empty 
@@ -141,7 +141,7 @@ pprError :: Verbosity -> Error -> SDoc
 pprError verb (TypeNotFound            id  ) = pprTypeNotFound verb id
 pprError verb (RecBinding              bind) = pprRecBinding   verb bind
 pprError verb (CompilationNotSupported bind) = pprCompilationNotSupported verb bind
-pprError verb (CompilationError    bind str) = pprCompilationError verb bind str
+pprError verb (CompilationError    bind str) = pprCompilationError verb bind $ vcat str
 pprError verb (OrderingFailedBinds d    bs) = pprOrderingFailedBinds verb d bs
 pprError verb (OrderingFailedTypes d    ts) = pprOrderingFailedTypes verb d ts
 pprError verb (OtherError          sdoc   ) = pprOtherError          verb sdoc

--- a/src/Foreign/Storable/Generic/Plugin/Internal/GroupTypes.hs
+++ b/src/Foreign/Storable/Generic/Plugin/Internal/GroupTypes.hs
@@ -32,7 +32,12 @@ import qualified GHC.Types.Name as N (varName)
 import GHC.Types.SrcLoc (noSrcSpan)
 import GHC.Types.Unique (getUnique)
 import GHC.Driver.Main (hscCompileCoreExpr, getHscEnv)
+#if MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+import GHC.Driver.Env.Types (HscEnv)
+import GHC.Unit.Module.ModGuts (ModGuts(..))
+#else
 import GHC.Driver.Types (HscEnv,ModGuts(..))
+#endif
 import GHC.Core.Opt.Monad (CoreM,CoreToDo(..))
 import GHC.Types.Basic (CompilerPhase(..))
 import GHC.Core.Type hiding (eqType)

--- a/src/Foreign/Storable/Generic/Plugin/Internal/Predicates.hs
+++ b/src/Foreign/Storable/Generic/Plugin/Internal/Predicates.hs
@@ -76,7 +76,12 @@ import qualified GHC.Types.Name as N (varName)
 import GHC.Types.SrcLoc (noSrcSpan)
 import GHC.Types.Unique (getUnique)
 import GHC.Driver.Main (hscCompileCoreExpr, getHscEnv)
+#if MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+import GHC.Driver.Env.Types (HscEnv)
+import GHC.Unit.Module.ModGuts (ModGuts(..))
+#else
 import GHC.Driver.Types (HscEnv,ModGuts(..))
+#endif
 import GHC.Core.Opt.Monad (CoreM,CoreToDo(..))
 import GHC.Types.Basic (CompilerPhase(..))
 import GHC.Core.Type (isAlgType, splitTyConApp_maybe)
@@ -277,4 +282,3 @@ withTypeCheck ty_f id_f id = do
     let ty_checked = ty_f $ varType id
         id_checked = id_f id
     and [isJust ty_checked, id_checked]
-

--- a/src/Foreign/Storable/Generic/Plugin/Internal/Types.hs
+++ b/src/Foreign/Storable/Generic/Plugin/Internal/Types.hs
@@ -51,7 +51,12 @@ import qualified GHC.Types.Name as N (varName, tcClsName)
 import GHC.Types.SrcLoc (noSrcSpan)
 import GHC.Types.Unique (getUnique)
 import GHC.Driver.Main (hscCompileCoreExpr, getHscEnv)
+#if MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+import GHC.Driver.Env.Types (HscEnv)
+import GHC.Unit.Module.ModGuts (ModGuts(..))
+#else
 import GHC.Driver.Types (HscEnv,ModGuts(..))
+#endif
 import GHC.Core.Opt.Monad (CoreM,CoreToDo(..))
 import GHC.Types.Basic (CompilerPhase(..))
 import GHC.Core.Type (isAlgType, splitTyConApp_maybe)


### PR DESCRIPTION
- `Env` and `ModGuts` are split into different modules.
- `Alt` is now a 3-constructor.
- Error messages are in a `Bag` (new module).