### PR TITLE
Fix linker error on GHC-8.2

### DIFF
--- a/derive-storable-plugin.cabal
+++ b/derive-storable-plugin.cabal
@@ -48,6 +48,9 @@ benchmark plugin-benchmark
   if flag(sumtypes)
     cpp-options: -DGSTORABLE_SUMTYPES
 
+  if impl(ghc < 8.4)
+    build-depends: text < 1.2.5.0
+
 test-suite c_alignment
   type:                exitcode-stdio-1.0
   


### PR DESCRIPTION
The tests are fine, but benchmark linking fails with:

> undefined reference to '__get_cpuid_count'