### PR TITLE
bumping upper ghc version bound from <9.7 to <9.9

### DIFF
--- a/derive-storable-plugin.cabal
+++ b/derive-storable-plugin.cabal
@@ -32,7 +32,7 @@ library
                        , Foreign.Storable.Generic.Plugin.Internal.Predicates
                        , Foreign.Storable.Generic.Plugin.Internal.Types
   other-extensions:    DeriveGeneric, DeriveAnyClass, PatternGuards
-  build-depends:       base >=4.10 && <5, ghc >= 8.2 && < 9.7, ghci >= 8.2 && < 9.7, derive-storable >= 0.3 && < 0.4
+  build-depends:       base >=4.10 && <5, ghc >= 8.2 && < 9.9, ghci >= 8.2 && < 9.9, derive-storable >= 0.3 && < 0.4
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
Hello, 

Current version `derive-storable-plugin` fails to build with `ghc-9.8` due to `ghc<9.7` bound in cabal.  This PR fixes it.


Cheers,
Vlad